### PR TITLE
Async update: support to collections

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/async.py
+++ b/lib/galaxy/webapps/galaxy/controllers/async.py
@@ -111,7 +111,6 @@ class ASync( BaseUIController ):
                     try:
                         GALAXY_TYPE = obj.format
                         outputs_count += 1
-                        break
                     except Exception:
                         # exclude outputs different from ToolOutput (e.g. collections) from the previous assumption
                         # a collection object does not have the 'format' attribute, so it will throw an exception

--- a/lib/galaxy/webapps/galaxy/controllers/async.py
+++ b/lib/galaxy/webapps/galaxy/controllers/async.py
@@ -76,7 +76,7 @@ class ASync( BaseUIController ):
                         TOOL_OUTPUT_TYPE = obj.format
                         params[tool.outputs.keys()[idx]] = data.id
                         break
-                    except:
+                    except Exception:
                         # exclude outputs different from ToolOutput (e.g. collections) from the previous assumption
                         continue
                 if TOOL_OUTPUT_TYPE is None:
@@ -112,7 +112,7 @@ class ASync( BaseUIController ):
                         GALAXY_TYPE = obj.format
                         outputs_count += 1
                         break
-                    except:
+                    except Exception:
                         # exclude outputs different from ToolOutput (e.g. collections) from the previous assumption
                         # a collection object does not have the 'format' attribute, so it will throw an exception
                         continue

--- a/lib/galaxy/webapps/galaxy/controllers/async.py
+++ b/lib/galaxy/webapps/galaxy/controllers/async.py
@@ -102,16 +102,19 @@ class ASync( BaseUIController ):
                 GALAXY_TYPE = params.data_type
             elif params.galaxyFileFormat == 'wig':  # this is an undocumented legacy special case
                 GALAXY_TYPE = 'wig'
+            elif params.GALAXY_TYPE:
+                GALAXY_TYPE = params.GALAXY_TYPE
             else:
                 # Assume there is exactly one output
                 outputs_count = 0
                 for obj in tool.outputs.values():
                     try:
-                        GALAXY_TYPE = params.GALAXY_TYPE or obj.format
+                        GALAXY_TYPE = obj.format
                         outputs_count += 1
                         break
                     except:
                         # exclude outputs different from ToolOutput (e.g. collections) from the previous assumption
+                        # a collection object does not have the 'format' attribute, so it will throw an exception
                         continue
                 if outputs_count > 1:
                     raise Exception( "Error: the tool should have just one output" )

--- a/lib/galaxy/webapps/galaxy/controllers/async.py
+++ b/lib/galaxy/webapps/galaxy/controllers/async.py
@@ -36,7 +36,7 @@ class ASync( BaseUIController ):
         STATUS = params.STATUS
         URL = params.URL
         data_id = params.data_id
-        
+
         log.debug('async dataid -> %s' % data_id)
         trans.log_event( 'Async dataid -> %s' % str(data_id) )
 
@@ -68,7 +68,7 @@ class ASync( BaseUIController ):
                 galaxy_url = trans.request.base + '/async/%s/%s/%s' % ( tool_id, data.id, key )
                 galaxy_url = params.get("GALAXY_URL", galaxy_url)
                 params = dict( URL=URL, GALAXY_URL=galaxy_url, name=data.name, info=data.info, dbkey=data.dbkey, data_type=data.ext )
-                
+
                 # Assume there is exactly one output file possible
                 TOOL_OUTPUT_TYPE = None
                 for idx, obj in enumerate(tool.outputs.values()):
@@ -81,7 +81,7 @@ class ASync( BaseUIController ):
                         continue
                 if TOOL_OUTPUT_TYPE is None:
                     raise Exception( "Error: ToolOutput object not found" )
-                
+
                 original_history = trans.sa_session.query( trans.app.model.History ).get( data.history_id )
                 tool.execute( trans, incoming=params, history=original_history )
             else:
@@ -115,7 +115,7 @@ class ASync( BaseUIController ):
                         continue
                 if outputs_count > 1:
                     raise Exception( "Error: the tool should have just one output" )
-                                
+
             if GALAXY_TYPE is None:
                 raise Exception( "Error: ToolOutput object not found" )
 
@@ -149,7 +149,7 @@ class ASync( BaseUIController ):
                 galaxy_url = trans.request.base + '/async/%s/%s/%s' % ( tool_id, data.id, key )
                 params.update( { 'GALAXY_URL': galaxy_url } )
                 params.update( { 'data_id': data.id } )
-                
+
                 # Use provided URL or fallback to tool action
                 url = URL or tool.action
                 # Does url already have query params?


### PR DESCRIPTION
The asynchronous procedure expects that only one output is defined in the tool XML schema. This improvement permits to define also collections. 

This feature is useful in conjunction with tools like [galaxy-json-collect-data-source](https://github.com/fabio-cumbo/galaxy-json-collect-data-source) (please see the README of the tool for more information).

It does not affect the behaviour of the asynchronous data sources previously developed.